### PR TITLE
feature: data dog log writer

### DIFF
--- a/datadog/writer.go
+++ b/datadog/writer.go
@@ -1,0 +1,98 @@
+package datadog
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/cultureamp/glamplify/helper"
+	"github.com/cultureamp/glamplify/log"
+)
+
+// writerConfig for setting initial values for Monitor Writer
+type writerConfig struct {
+	// license is your Data Dog API key.
+	//
+	// https://app.datadoghq.com/account/settings#api
+	apiKey string
+
+	// URL: https://http-intake.logs.datadoghq.com/v1/input  (default)
+	endpoint string
+
+	// timeout
+	timeout time.Duration
+
+	omitempty bool
+}
+
+// FieldWriter sends logging output to Data Dog
+type FieldWriter struct {
+	mutex  sync.Mutex
+	config writerConfig
+}
+
+// NewDataDogWriter creates a new FieldWriter. The optional configure func lets you set values on the underlying  writer.
+func NewDataDogWriter(configure ...func(*writerConfig)) *FieldWriter { // https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+	conf := writerConfig{
+		apiKey:    os.Getenv("DD_CLIENT_API_KEY"),
+		endpoint:  helper.GetEnvString("DATA_DOG_LOG_ENDPOINT", "https://http-intake.logs.datadoghq.com/v1/input"),
+		timeout:   time.Second * time.Duration(helper.GetEnvInt("DATA_DOG_TIMEOUT", 5)),
+		omitempty: helper.GetEnvBool(log.OmitEmpty, false),
+	}
+
+	for _, config := range configure {
+		config(&conf)
+	}
+
+	writer := &FieldWriter{
+		config: conf,
+	}
+
+	return writer
+}
+
+//WriteFields - writes fields to the Data Dog log endpoint
+func (writer *FieldWriter) WriteFields(sev int, system log.Fields, fields ...log.Fields) {
+
+	merged := log.Fields{}
+	properties := merged.Merge(fields...)
+	if len(properties) > 0 {
+		system[log.Properties] = properties
+	}
+
+	json := system.ToSnakeCase().ToJson(writer.config.omitempty)
+
+	go post(writer.config, json)
+}
+
+func post(config writerConfig, jsonStr string) error {
+
+	jsonBytes := []byte(jsonStr)
+
+	req, err := http.NewRequest("POST", config.endpoint, bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("DD-API-KEY", config.apiKey)
+
+	var client = &http.Client{
+		Timeout: config.timeout,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		return nil
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	str := string(body)
+	return fmt.Errorf("bad server response: %d. body: %v", resp.StatusCode, str)
+}

--- a/datadog/writer_test.go
+++ b/datadog/writer_test.go
@@ -1,0 +1,36 @@
+package datadog
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	gcontext "github.com/cultureamp/glamplify/context"
+	"github.com/cultureamp/glamplify/log"
+)
+
+func Test_DataDog_RealWorld(t *testing.T) {
+
+	if key := os.Getenv("DD_CLIENT_API_KEY"); key == "" {
+		t.Skip("no data dog api key set")
+	}
+
+	ctx := context.Background()
+	ctx = gcontext.AddRequestFields(ctx, gcontext.RequestScopedFields{
+		TraceID:             "1-2-3",
+		RequestID:           "7-8-9",
+		CorrelationID:       "1-5-9",
+		CustomerAggregateID: "hooli",
+		UserAggregateID:     "UserAggregateID-123",
+	})
+
+	writer := NewDataDogWriter(func(config *writerConfig) {
+		config.endpoint = "https://http-intake.logs.datadoghq.com/v1/input"
+	})
+
+	logger := log.NewFromCtxWithCustomerWriter(ctx, writer)
+
+	logger.Info("hello Data Dog")
+	time.Sleep(2 * time.Second)
+}


### PR DESCRIPTION
A decision has been made to end our contract with New Relic and move to Data Dog.

This PR introduces a custom writer that can be used to write logs to Data Dog via the glamplify logger

cc @jamestelfer 
