### PR TITLE
Now check user fields (properties) for reserved global variables as well 

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -174,12 +174,12 @@ func (logger Logger) write(rsFields gcontext.RequestScopedFields, event string, 
 
 	sev := sevLevel.stringToLevel(severity)
 	if sevLevel.shouldLog(sev) {
-		system := logger.sysValues.getSystemValues(rsFields, event, severity)
+		properties := logger.fields.Merge(fields...)
+		system := logger.sysValues.getSystemValues(rsFields, properties, event, severity)
 		if err != nil {
 			system = logger.sysValues.getErrorValues(err, system)
 		}
 
-		properties := logger.fields.Merge(fields...)
 		logger.writer.WriteFields(sev, system, properties)
 	}
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -102,6 +102,25 @@ func Test_Log_IsEnabled(t *testing.T) {
 	assert.Assert(t, sevLevel.shouldLog(level), sevLevel.shouldLog(level))
 }
 
+func Test_Log_Global_Scope(t *testing.T) {
+	memBuffer := &bytes.Buffer{}
+	writer := NewWriter(func(conf *WriterConfig) {
+		conf.Output = memBuffer
+	})
+	logger := NewWitCustomWriter(rsFields, writer)
+
+	logger.Event( "detail_event").Fields(Fields{
+		AppNameEnv: "app_name",
+		AppFarmEnv: "app_farm",
+	}).Debug("debug")
+
+	msg := memBuffer.String()
+	assertContainsString(t, msg, "event", "detail_event")
+	assertContainsString(t, msg, "severity", "DEBUG")
+	assertContainsString(t, msg, "app", "app_name")
+	assertContainsString(t, msg, "farm", "app_farm")
+}
+
 func Test_Log_Debug(t *testing.T) {
 
 	memBuffer := &bytes.Buffer{}

--- a/log/system_test.go
+++ b/log/system_test.go
@@ -23,7 +23,7 @@ func Test_HostName(t *testing.T) {
 func Test_Default(t *testing.T) {
 	df := newSystemValues()
 
-	fields := df.getSystemValues(rsFields, "event_name", DebugSev)
+	fields := df.getSystemValues(rsFields, nil, "event_name", DebugSev)
 
 	_, ok := fields[Time]
 	assert.Assert(t, ok, "missing 'time' in default fields")
@@ -56,7 +56,7 @@ func Test_Default(t *testing.T) {
 func Test_ErrorDefault(t *testing.T) {
 	df := newSystemValues()
 
-	fields := df.getSystemValues(rsFields, "event_name", DebugSev)
+	fields := df.getSystemValues(rsFields, nil, "event_name", DebugSev)
 	fields = df.getErrorValues(errors.New("test err"), fields)
 
 	_, ok := fields[Exception]


### PR DESCRIPTION
We weren't checking the user fields correctly, now that is passed in a checked as well, so that we correctly promote user fields if they match the global ones.

I don't remove them from the user fields currently (I think they should stay there, but I could be talked out of that).