### PR TITLE
Big clean up of level's for all writers

### DIFF
--- a/datadog/writer_test.go
+++ b/datadog/writer_test.go
@@ -40,3 +40,21 @@ func Test_DataDog_Writer(t *testing.T) {
 	assert.Assert(t, json != "", json)
 	assert.Assert(t, strings.Contains(json, "hello"), json)
 }
+
+func Test_DataDog_Writer_IsEnabled(t *testing.T) {
+
+	writer := NewDataDogWriter(func(config *DDFieldWriter) {
+		config.Level = log.ErrorSev
+	})
+
+	ok := writer.IsEnabled(log.DebugSev)
+	assert.Assert(t, !ok, ok)
+	ok = writer.IsEnabled(log.InfoSev)
+	assert.Assert(t, !ok, ok)
+	ok = writer.IsEnabled(log.WarnSev)
+	assert.Assert(t, !ok, ok)
+	ok = writer.IsEnabled(log.ErrorSev)
+	assert.Assert(t, ok, ok)
+	ok = writer.IsEnabled(log.FatalSev)
+	assert.Assert(t, ok, ok)
+}

--- a/log/level.go
+++ b/log/level.go
@@ -1,12 +1,8 @@
 package log
 
-import (
-	"os"
-)
-
-type systemLogLevel struct {
-	sysLogLevel int
-	stol        map[string]int
+// Leveller manages the conversion of log levels to and from string to int
+type Leveller struct {
+	stol map[string]int
 }
 
 const (
@@ -17,8 +13,7 @@ const (
 	FatalLevel
 )
 
-
-func newSystemLogLevel() *systemLogLevel {
+func NewLevelMap() *Leveller {
 
 	table := map[string]int{
 		DebugSev: DebugLevel,
@@ -28,22 +23,12 @@ func newSystemLogLevel() *systemLogLevel {
 		FatalSev: FatalLevel,
 	}
 
-	level, ok := os.LookupEnv(Level)
-	if !ok {
-		level = DebugSev
-	}
-	logLevel, found := table[level]
-	if !found {
-		logLevel = DebugLevel
-	}
-
-	return &systemLogLevel{
-		sysLogLevel: logLevel,
-		stol:        table,
+	return &Leveller{
+		stol: table,
 	}
 }
 
-func (sev systemLogLevel) stringToLevel(severity string) int {
+func (sev Leveller) StringToLevel(severity string) int {
 	level, ok := sev.stol[severity]
 	if ok {
 		return level
@@ -52,12 +37,16 @@ func (sev systemLogLevel) stringToLevel(severity string) int {
 	return DebugLevel
 }
 
-func (sev systemLogLevel) shouldLog(severity int) bool {
+func (sev Leveller) ShouldLogSeverity(level string, severity string) bool {
+	l := sev.StringToLevel(level)
+	s := sev.StringToLevel(severity)
 
-	if severity >= sev.sysLogLevel {
-		return true
-	}
-
-	return false
+	return sev.ShouldLogLevel(l, s)
 }
 
+func (sev Leveller) ShouldLogLevel(level int, severity int) bool {
+	if severity >= level {
+		return true
+	}
+	return false
+}

--- a/log/level_test.go
+++ b/log/level_test.go
@@ -2,68 +2,48 @@ package log
 
 import (
 	"gotest.tools/assert"
-	"os"
 	"testing"
 )
 
-func Test_Sev_Log(t *testing.T) {
+func Test_ShouldLogLevel(t *testing.T) {
 
-	sev := newSystemLogLevel()
+	leveller := NewLevelMap()
 
-	ok := sev.shouldLog(DebugLevel)
+	ok := leveller.ShouldLogLevel(DebugLevel, DebugLevel)
 	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(InfoLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(WarnLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(ErrorLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(FatalLevel)
+	ok = leveller.ShouldLogLevel(InfoLevel, DebugLevel)
+	assert.Assert(t, !ok, ok)
+	ok = leveller.ShouldLogLevel(DebugLevel, InfoLevel)
 	assert.Assert(t, ok, ok)
 }
 
-func Test_Sev_Log_Env(t *testing.T) {
+func Test_ShouldLogSeverity(t *testing.T) {
 
-	os.Setenv("LOG_LEVEL", WarnSev)
-	defer os.Unsetenv("LOG_LEVEL")
+	leveller := NewLevelMap()
 
-	sev := newSystemLogLevel()
-
-	ok := sev.shouldLog(DebugLevel)
-	assert.Assert(t, !ok, ok)
-	ok = sev.shouldLog(InfoLevel)
-	assert.Assert(t, !ok, ok)
-	ok = sev.shouldLog(WarnLevel)
+	ok := leveller.ShouldLogSeverity(DebugSev, DebugSev)
 	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(ErrorLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(FatalLevel)
+	ok = leveller.ShouldLogSeverity(InfoSev, DebugSev)
+	assert.Assert(t, !ok, ok)
+	ok = leveller.ShouldLogSeverity(DebugSev, InfoSev)
 	assert.Assert(t, ok, ok)
 }
 
-func Test_Sev_Log_Unknown(t *testing.T) {
+func Test_StringToLevel(t *testing.T) {
 
-	sev := newSystemLogLevel()
+	leveller := NewLevelMap()
 
-	ok := sev.shouldLog(-1)
-	assert.Assert(t, !ok, ok)
-}
+	level := leveller.StringToLevel(DebugSev)
+	assert.Assert(t, level == DebugLevel)
+	level = leveller.StringToLevel(InfoSev)
+	assert.Assert(t, level == InfoLevel)
+	level = leveller.StringToLevel(WarnSev)
+	assert.Assert(t, level == WarnLevel)
+	level = leveller.StringToLevel(ErrorSev)
+	assert.Assert(t, level == ErrorLevel)
+	level = leveller.StringToLevel(FatalSev)
+	assert.Assert(t, level == FatalLevel)
+	level = leveller.StringToLevel("bad")
+	assert.Assert(t, level == DebugLevel)
 
-func Test_Sev_Log_Env_Unknown(t *testing.T) {
-
-	os.Setenv("LOG_LEVEL", "unknown")
-	defer os.Unsetenv("LOG_LEVEL")
-
-	sev := newSystemLogLevel()
-
-	ok := sev.shouldLog(DebugLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(InfoLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(WarnLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(ErrorLevel)
-	assert.Assert(t, ok, ok)
-	ok = sev.shouldLog(FatalLevel)
-	assert.Assert(t, ok, ok)
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -87,19 +87,16 @@ func Test_NewWithRequest(t *testing.T) {
 }
 
 func Test_Log_IsEnabled(t *testing.T) {
-	logger := NewFromCtx(ctx)
+	writer := NewWriter(func(config *WriterConfig) {
+		config.Level =  WarnSev
+	})
+	logger := NewFromCtxWithCustomerWriter(ctx, writer)
 	assert.Assert(t, logger != nil, logger)
 
-	assert.Assert(t, logger.IsEnabled(DebugSev), logger.IsEnabled(DebugSev))
-
-	os.Setenv("LOG_LEVEL", InfoSev)
-	defer os.Unsetenv("LOG_LEVEL")
-	sevLevel := newSystemLogLevel()
-
-	level := sevLevel.stringToLevel(DebugSev)
-	assert.Assert(t, !sevLevel.shouldLog(level), sevLevel.shouldLog(level))
-	level = sevLevel.stringToLevel(InfoSev)
-	assert.Assert(t, sevLevel.shouldLog(level), sevLevel.shouldLog(level))
+	assert.Assert(t, !logger.IsEnabled(DebugSev), logger.IsEnabled(DebugSev))
+	assert.Assert(t, !logger.IsEnabled(InfoSev), logger.IsEnabled(InfoSev))
+	assert.Assert(t, logger.IsEnabled(WarnSev), logger.IsEnabled(WarnSev))
+	assert.Assert(t, logger.IsEnabled(ErrorSev), logger.IsEnabled(ErrorSev))
 }
 
 func Test_Log_Global_Scope(t *testing.T) {

--- a/log/writer_test.go
+++ b/log/writer_test.go
@@ -16,7 +16,7 @@ func Test_WriteFields(t *testing.T) {
 		conf.OmitEmpty = false
 	})
 
-	writer.WriteFields(DebugLevel, Fields{
+	writer.WriteFields(DebugSev, Fields{
 		"system":       "system_value",
 		"system_empty": "",
 	}, Fields{
@@ -39,7 +39,7 @@ func Test_WriteFields_OmitEmpty(t *testing.T) {
 		conf.OmitEmpty = true
 	})
 
-	writer.WriteFields(DebugLevel,
+	writer.WriteFields(DebugSev,
 		Fields{
 			"system":       "system_value",
 			"system_empty": "",
@@ -53,6 +53,23 @@ func Test_WriteFields_OmitEmpty(t *testing.T) {
 	assertKeyMissing(t, msg, "system_empty")
 	assertStringContains(t, msg, "properties", "properties_value")
 	assertKeyMissing(t, msg, "properties_empty")
+}
+
+func Test_WriteFields_IsEnabled(t *testing.T) {
+	writer := NewWriter(func(conf *WriterConfig) {
+		conf.Level = InfoSev
+	})
+
+	ok := writer.IsEnabled(DebugSev)
+	assert.Assert(t, !ok, ok)
+	ok = writer.IsEnabled(InfoSev)
+	assert.Assert(t, ok, ok)
+	ok = writer.IsEnabled(WarnSev)
+	assert.Assert(t, ok, ok)
+	ok = writer.IsEnabled(ErrorSev)
+	assert.Assert(t, ok, ok)
+	ok = writer.IsEnabled(FatalSev)
+	assert.Assert(t, ok, ok)
 }
 
 func assertStringContains(t *testing.T, log string, key string, val string) {

--- a/newrelic/writer_test.go
+++ b/newrelic/writer_test.go
@@ -2,12 +2,13 @@ package newrelic
 
 import (
 	"context"
-	"github.com/cultureamp/glamplify/log"
-	"gotest.tools/assert"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cultureamp/glamplify/log"
+	"gotest.tools/assert"
 )
 
 func Test_NewRelic_Writer(t *testing.T) {
@@ -18,7 +19,7 @@ func Test_NewRelic_Writer(t *testing.T) {
 	ctx := context.Background()
 
 	// https://log-api.newrelic.com/log/v1
-	writer := newWriter(func(config *NRFieldWriter) {
+	writer := NewNRWriter(func(config *NRFieldWriter) {
 		config.Endpoint ="https://log-api.newrelic.com/log/v1"
 		config.Timeout =  time.Second * time.Duration(2)
 	})
@@ -29,4 +30,22 @@ func Test_NewRelic_Writer(t *testing.T) {
 
 	assert.Assert(t, json != "", json)
 	assert.Assert(t, strings.Contains(json, "hello"), json)
+}
+
+func Test_NewRelic_Writer_IsEnabled(t *testing.T) {
+
+	writer := NewNRWriter(func(config *NRFieldWriter) {
+		config.Level = log.WarnSev
+	})
+
+	ok := writer.IsEnabled(log.DebugSev)
+	assert.Assert(t, !ok, ok)
+	ok = writer.IsEnabled(log.InfoSev)
+	assert.Assert(t, !ok, ok)
+	ok = writer.IsEnabled(log.WarnSev)
+	assert.Assert(t, ok, ok)
+	ok = writer.IsEnabled(log.ErrorSev)
+	assert.Assert(t, ok, ok)
+	ok = writer.IsEnabled(log.FatalSev)
+	assert.Assert(t, ok, ok)
 }


### PR DESCRIPTION
Now writers have the log_level (rather than the logger) and they control if they log the message or not. They also return the string (json) that they log (or would have logged) back to logger, and the logger back to the client. This might be useful if a client wants to know what is logged out - but 99% of cases it can ignore this return value.