### PR TITLE
Integrate with Backstage (Modify Me!)

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -1,0 +1,58 @@
+name: Publish TechDocs Site
+
+on:
+  push:
+    branches: [master]
+    # Set it to run only when TechDocs related files are updated.
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
+jobs:
+  publish-techdocs-site:
+    runs-on: ubuntu-latest
+    
+    env:
+      TECHDOCS_S3_BUCKET_NAME: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.TECHDOCS_AWS_REGION }}
+      ENTITY_NAMESPACE: 'default'
+      ENTITY_KIND: 'Component'
+
+      ENTITY_NAME: 'glamplify'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install techdocs-cli
+        run: sudo npm install -g @techdocs/cli
+
+      - name: Install mkdocs and mkdocs plugins
+        run: python -m pip install mkdocs-techdocs-core==0.*
+
+      - name: Generate docs site
+        run: techdocs-cli generate --no-docker --verbose
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+
+          aws-access-key-id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.TECHDOCS_AWS_REGION }}
+          role-to-assume: ${{ secrets.TECHDOCS_AWS_ROLE_TO_ASSUME }}
+          role-external-id: ${{ secrets.TECHDOCS_AWS_ROLE_EXTERNAL_ID }}
+
+          role-duration-seconds: 900
+          role-session-name: github-actions-publish-techdocs
+
+      - name: Publish docs site
+        run:
+          techdocs-cli publish --publisher-type awsS3 --storage-name
+          $TECHDOCS_S3_BUCKET_NAME --entity
+          $ENTITY_NAMESPACE/$ENTITY_KIND/$ENTITY_NAME

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,31 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: glamplify
+  description:  # It would be nice if this matched the github repo description and that was a succinct sentence 
+  links:
+    - title: Website
+      url: https://github.com/cultureamp/glamplify
+    - title: Monitoring Dashboard
+      url: https://app.datadoghq.com/apm/service/glamplify/http.request?env=production-us # If this link is broken feel free to link to another monitoring view. Alternatively leave as is and create the Datadog dashboard. 
+  #
+  # Tags are required and are based on:
+  # https://cultureamp.atlassian.net/wiki/spaces/CPlatform/pages/1720156463/Authentication+-+One+Platform+Technical+Canvas
+  # Please select values from the options provided
+  tags: 
+    - tier- # tier-1 | tier-2 | tier-3
+    - health- # health-good | health-moderate | health-poor
+    - users- # users-internal | users-account-admins | users-customer-facing | users-na
+    - camp- # e.g camp-platform | camp-perform | camp-example
+    - data- # data-confidential | data-restricted | data-internal-use-only | data-public | data-none
+  annotations:
+    github.com/project-slug: cultureamp/glamplify
+    github.com/team-slug: cultureamp/sre 
+    backstage.io/techdocs-ref: url:https://github.com/cultureamp/blob/master/glamplify
+    buildkite.com/project-slug: culture-amp/glamplify # Check Me! - this was guessed and may be incorrect
+    # pagerduty.com/integration-key: create an integration key and use its ID here - https://support.pagerduty.com/docs/services-and-integrations
+    # sentry.io/project-slug: glamplify # Uncomment this line if using Sentry
+spec:
+  type: # openapi | website | service | library
+  owner: sre # Backstage Teamname should be the same as the Github Team Name (these teams are synced between github and backstage)
+  lifecycle: production # experimental | development | production | deprecated | contained

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+Holding file for Docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: ''
+site_description: ''
+
+plugins:
+  - techdocs-core
+
+nav:
+  - Overview:
+    - Placeholder: 'index.md'


### PR DESCRIPTION
## Purpose

This PR adds the configuration required for your component to be registered in our service catalogue "Backstage" - [Access Backstage](https://backstage.usw2.dev-us.cultureamp.io) (Dev VPN required)

## Before Merging

All comments in the `catalog-info.yaml` should be deleted before merging as their only purpose is to support this PR.  

It is strongly recommended you review and change this PR to suit the component in this repo with as much detail as possible.

Please consult the [backstage docs](https://backstage.usw2.dev-us.cultureamp.io/catalog/default/component/backstage/docs) and reach out to Mark Walford or the central SRE team #team_sre for help.

## Changes

This PR adds the following:

1. A `catalog-info.yaml` file. Required by backstage, this file defines this repo in the service catalog.
 The `catalog-info.yaml` is not complete. Please review and makes changes where necessary. Remove all comments.
2. A `mkdocs.yml` file. This file defines the backstage techdocs nav and document location (usually ./docs this folder is created if it does not already exist)
  Consult the cultureamp/backstage repo for an example [here](https://github.com/cultureamp/backstage/blob/development/mkdocs.yml)
  * Expecting varying thoughts and issues here. Please reach out with your use case or suggestions *
3. A Github Workflow that compiles the docs in the repo and pushes them to s3 for consumption in backstage