### PR TITLE
[v2] Add primitive/pointer conversion utility package

### DIFF
--- a/ref/doc.go
+++ b/ref/doc.go
@@ -1,0 +1,4 @@
+// The `ref` package supplies a way for Go code to create references to literals
+// or other expressions that would typically require a variable declaration.
+// This simplifies expressions, particularly struct initializations.
+package ref

--- a/ref/ref.go
+++ b/ref/ref.go
@@ -1,0 +1,59 @@
+package ref
+
+import (
+	"reflect"
+	"time"
+)
+
+// Bool returns a reference to the value passed as a parameter.
+func Bool(i bool) *bool {
+	return &i
+}
+
+// Int returns a reference to the value passed as a parameter.
+func Int(i int) *int {
+	return &i
+}
+
+// Int64 returns a reference to the value passed as a parameter.
+func Int64(i int64) *int64 {
+	return &i
+}
+
+// String returns a reference to the value passed as a parameter.
+func String(i string) *string {
+	return &i
+}
+
+// Duration returns a reference to the value passed as a parameter.
+func Duration(i time.Duration) *time.Duration {
+	return &i
+}
+
+// Strings returns a new array of pointers that has the same length as the
+// supplied array, and whose elements contain pointers to strings in the
+// equivalent indexes from the supplied array.
+func Strings(ss []string) []*string {
+	r := make([]*string, len(ss))
+	for i := range ss {
+		r[i] = &ss[i]
+	}
+	return r
+}
+
+// ToStructPointer creates an interface{} instance that is a pointer to the
+// underlying struct value of the supplied instance of interface{}. So if a{} is
+// supplied, this will return &a{}.
+func ToStructPointer(a interface{}) interface{} {
+	v := reflect.ValueOf(a)
+	vp := reflect.New(reflect.TypeOf(a))
+	vp.Elem().Set(v)
+
+	return vp.Interface()
+}
+
+// ToStruct returns a reference representing the value of the supplied pointer.
+// So if *a{} is supplied, a{} will be returned.
+func ToStruct(ptr interface{}) interface{} {
+	return reflect.ValueOf(ptr).Elem().Interface()
+}

--- a/ref/ref_test.go
+++ b/ref/ref_test.go
@@ -1,0 +1,95 @@
+package ref_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cultureamp/glamplify/ref"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ExampleType struct {
+	Member *string
+}
+
+func ExampleString() {
+	val := "value1"
+
+	ex1 := ExampleType{
+		Member: &val,
+	}
+
+	ex2 := ExampleType{
+		Member: ref.String("value2"),
+	}
+
+	fmt.Printf("%s %s\n", *ex1.Member, *ex2.Member)
+	// Output: value1 value2
+}
+
+func Test_Int(t *testing.T) {
+	i := int(49392)
+	ptr := ref.Int(i)
+
+	require.NotNil(t, ptr)
+	assert.Equal(t, i, *ptr)
+}
+
+func Test_Int64(t *testing.T) {
+	i := int64(49392215732365141)
+	ptr := ref.Int64(i)
+
+	require.NotNil(t, ptr)
+	assert.Equal(t, i, *ptr)
+}
+
+func Test_Bool(t *testing.T) {
+	b := true
+	ptr := ref.Bool(b)
+
+	require.NotNil(t, ptr)
+	assert.Equal(t, b, *ptr)
+}
+
+func Test_Duration(t *testing.T) {
+	d := time.Millisecond
+	ptr := ref.Duration(d)
+
+	require.NotNil(t, ptr)
+	assert.Equal(t, d, *ptr)
+}
+
+func Test_String(t *testing.T) {
+	str := "flamingo"
+	strPtr := ref.String(str)
+
+	require.NotNil(t, strPtr)
+	assert.Equal(t, str, *strPtr)
+}
+
+func Test_Strings(t *testing.T) {
+	slice := []string{"flamingo", "swan", "shag"}
+	slicePtr := ref.Strings(slice)
+
+	require.NotNil(t, slicePtr)
+	require.Len(t, slicePtr, len(slice))
+	actual := make([]string, len(slicePtr))
+	for i, e := range slicePtr {
+		actual[i] = *e
+	}
+	assert.Equal(t, slice, actual)
+}
+
+type mirror struct {
+	who      string
+	greatest bool
+}
+
+func Test_StructPtr(t *testing.T) {
+	start := interface{}(mirror{who: "goat", greatest: true})
+	finish := ref.ToStruct(ref.ToStructPointer(start))
+
+	assert.Equal(t, start, finish)
+}


### PR DESCRIPTION
## Purpose

It’s common in code that deals with serialisation types to require a pointer to a literal value, or to an expression result. These utilities allow this without requiring a separate variable declaration.

For example,

```go
// instead of
ptr := "literal"
t := Blah{ foo = ptr }

// you can just do
t := Blah{ foo = ref.String("literal") }
```

There is inspiration here from the [AWS go library](https://github.com/aws/aws-sdk-go-v2/blob/main/aws/to_ptr.go), but it isn't approriate to just use that everywhere.