### PR TITLE
Update backstage catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,6 @@ metadata:
     - title: Github
       url: https://github.com/cultureamp/glamplify
   tags:
-    - health-good
     - users-internal
     - camp-platform
     - data-none


### PR DESCRIPTION
This PR updates the backstage catalog as part of sock-keeping day.

It just removes a deprecated field (`health`)